### PR TITLE
Disable symbol array and word array cops

### DIFF
--- a/oct_rubocop.yml
+++ b/oct_rubocop.yml
@@ -6,3 +6,9 @@ Style/Documentation:
 
 Metrics/LineLength:
   Max: 100
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false


### PR DESCRIPTION
I propose that we disable the Style/SymbolArray and Style/WordArray cops. I feel that the % notation, while sometimes useful, can be less intuitive and less readable than writing out the array normally, so I would like the choice to be up to the discretion of the developer.

Documentation & examples of cops:
https://rubocop.readthedocs.io/en/latest/cops_style/#stylesymbolarray
```
# good
%i[foo bar baz]

# bad
[:foo, :bar, :baz]
```
https://rubocop.readthedocs.io/en/latest/cops_style/#stylewordarray
```
# good
%w[foo bar baz]

# bad
['foo', 'bar', 'baz']
```