### PR TITLE
Exempt TODO comments from line length cop

### DIFF
--- a/oct_rubocop.yml
+++ b/oct_rubocop.yml
@@ -6,3 +6,4 @@ Style/Documentation:
 
 Metrics/LineLength:
   Max: 100
+  IgnoredPatterns: ['# TODO']


### PR DESCRIPTION
This would exempt TODO comments from the 100 character line length requirement.

Here's an example of what we're trying to avoid:
```ruby
feature description, type: :acceptance, sauce: app.sauce, broken: true do # TODO: This test is
  # broken due to an issue running on Internet Explorer on Sauce Labs. A support ticket has
  # been submitted.
  let(:user) { app.user('1lead', client_type) }
```

Here's an example of how it would look with this rubocop exception in place:
```ruby
feature description, type: :acceptance, sauce: app.sauce, broken: true do # TODO: This test is broken due to an issue running on Internet Explorer on Sauce Labs. A support ticket has been submitted.
  let(:user) { app.user('1lead', client_type) }
```