### PR TITLE
Exempt rspec tests from block length cop

### DIFF
--- a/oct_rubocop.yml
+++ b/oct_rubocop.yml
@@ -4,5 +4,9 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/LineLength:
   Max: 100


### PR DESCRIPTION
I propose we exempt RSpec tests from the block length cop. RSpec features are a special case and I don't think the block length restriction is very applicable or helpful. Please feel free to start a discussion if you have a differing opinion.

Here's an example of what I feel is a very reasonable API test that sets off this cop with an error of
```
Metrics/BlockLength: Block has too many lines. [33/25]
```
https://github.com/octanner/gunter/blob/be613259e42e93c665ec07b64af0153022858dc6/spec/requests/api/v1/testsuites_controller_spec.rb