### PR TITLE
Add the rubocop-rspec gem for RSpec cops.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,2 @@
-require: rubocop-rspec
-
 inherit_from:
   - oct_rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,4 @@
+require: rubocop-rspec
+
 inherit_from:
   - oct_rubocop.yml

--- a/lib/oct/rubocop/version.rb
+++ b/lib/oct/rubocop/version.rb
@@ -1,5 +1,5 @@
 module Oct
   module Rubocop
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/oct-rubocop.gemspec
+++ b/oct-rubocop.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop-rspec'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/oct_rubocop.yml
+++ b/oct_rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 AllCops:
   Exclude:
     - '**/bin/*'


### PR DESCRIPTION
We have a few RSpec cops defined in the `oct_rubocop.yml` file.  But the RSpec cops were spun out of `rubocop` into their own gem: `rubocop-rspec`.  This results in warning about `unrecognized cop` when executed (and, of course, we don't get the policeing for those cops).

Since we presumably still want RSpec cops, this PR adds the `rubocop-rspec` gem as a dependency, and loads up the RSpec cops.  👮 

If we don't want the RSpec cops, we should just remove the configuration for those cops.