### PR TITLE
Update cops for upstream changes.

### DIFF
--- a/lib/oct/rubocop/version.rb
+++ b/lib/oct/rubocop/version.rb
@@ -1,5 +1,5 @@
 module Oct
   module Rubocop
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.2.1'.freeze
   end
 end

--- a/oct_rubocop.yml
+++ b/oct_rubocop.yml
@@ -47,11 +47,11 @@ Style/Documentation:
 Metrics/LineLength:
   Max: 100
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: true
   EnforcedStyle: 'with_fixed_indentation'
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 Layout/MultilineMethodCallIndentation:

--- a/oct_rubocop.yml
+++ b/oct_rubocop.yml
@@ -44,7 +44,7 @@ Metrics/AbcSize:
 Style/Documentation:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Layout/ParameterAlignment:


### PR DESCRIPTION
https://jira.octanner.com/browse/ES-1109

Rubocop changed some of the cop names and namespaces, which is preventing our legacy Ruby applications from passing automated quality testing.