### PR TITLE
CORE-7437 : Update libraries to resolve CVEs

### DIFF
--- a/lib/oct/rubocop/version.rb
+++ b/lib/oct/rubocop/version.rb
@@ -1,5 +1,5 @@
 module Oct
   module Rubocop
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
   end
 end

--- a/oct-rubocop.gemspec
+++ b/oct-rubocop.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop'
   spec.add_dependency 'rubocop-rspec'
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '~> 2.3'
+  spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
[CORE-7437](https://jira.octanner.com/browse/CORE-7437)
[CM-22571](https://jira.octanner.com/browse/CM-22571)

* Update `bundler` and `rake` versions

NOTE:  This gem is actually just a list of code quality rules and targets.  There is no actual functionality in the gem.  The CVE reports are development dependencies that are used to pull the default `rubocop` definitions and package the gem.